### PR TITLE
Allow URL in uptimerobot_monitor datasource

### DIFF
--- a/internal/provider/api/monitor.go
+++ b/internal/provider/api/monitor.go
@@ -218,7 +218,7 @@ func (client UptimeRobotApiClient) GetMonitor(id int) (m Monitor, err error) {
 		// m.HTTPMethod = intToString(monitorHTTPMethod, int(monitor["http_method"].(float64)))
 		m.HTTPUsername = monitor["http_username"].(string)
 		m.HTTPPassword = monitor["http_password"].(string)
-	case m.Type != "heartbeat":
+	case m.Type == "heartbeat":
 		m.URL = monitor["url"].(string)
 	}
 


### PR DESCRIPTION
Hi there,
we are using your terraform provider for uptimerobot and currently it is not possibile to get the URL from the uptimerobot_monitor datasource.

The API allows getting this info and the proposed change would allow this.

We need to get the URL from the data provider as it is the only way to get a heartbeat URL from uptimerobot in terraform