### PR TITLE
fix(provider): make sure deletion is idempotent

### DIFF
--- a/internal/provider/api/alert_contact.go
+++ b/internal/provider/api/alert_contact.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // maximum pagination depth to allow (10*50=500 entries)
@@ -216,8 +217,13 @@ func (client UptimeRobotApiClient) DeleteAlertContact(id string) (err error) {
 		"deleteAlertContact",
 		data.Encode(),
 	)
-	if err != nil {
+	if err == nil {
 		return
+	}
+
+	// Idempotent delete — see DeleteMonitor for rationale.
+	if _, getErr := client.GetAlertContact(id); getErr != nil && strings.Contains(getErr.Error(), "not found") {
+		return nil
 	}
 	return
 }

--- a/internal/provider/api/client.go
+++ b/internal/provider/api/client.go
@@ -7,13 +7,25 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
 
 func New(apiKey string) UptimeRobotApiClient {
 	return UptimeRobotApiClient{apiKey}
+}
+
+func envInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
 }
 
 type UptimeRobotApiClient struct {
@@ -26,7 +38,14 @@ func (client UptimeRobotApiClient) MakeCall(
 ) (map[string]interface{}, error) {
 	log.Printf("[DEBUG] Making request to: %#v", endpoint)
 
-	url := "https://api.uptimerobot.com/v2/" + endpoint
+	base := os.Getenv("UPTIMEROBOT_API_URL")
+	if base == "" {
+		base = "https://api.uptimerobot.com/v2/"
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	url := base + endpoint
 
 	payload := strings.NewReader(
 		fmt.Sprintf("api_key=%s&format=json&%s", client.apiKey, params),
@@ -38,7 +57,13 @@ func (client UptimeRobotApiClient) MakeCall(
 	req.Header.Add("content-type", "application/x-www-form-urlencoded")
 
 	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 10
+	retryClient.RetryMax = envInt("UPTIMEROBOT_RETRY_MAX", 10)
+	if v := envInt("UPTIMEROBOT_RETRY_WAIT_MIN_SECONDS", 0); v > 0 {
+		retryClient.RetryWaitMin = time.Duration(v) * time.Second
+	}
+	if v := envInt("UPTIMEROBOT_RETRY_WAIT_MAX_SECONDS", 0); v > 0 {
+		retryClient.RetryWaitMax = time.Duration(v) * time.Second
+	}
 	standardClient := retryClient.StandardClient()
 
 	res, err := standardClient.Do(req)

--- a/internal/provider/api/monitor.go
+++ b/internal/provider/api/monitor.go
@@ -459,8 +459,17 @@ func (client UptimeRobotApiClient) DeleteMonitor(id int) (err error) {
 		"deleteMonitor",
 		data.Encode(),
 	)
-	if err != nil {
+	if err == nil {
 		return
+	}
+
+	// The UptimeRobot API can drop responses to bulk deletes (retry
+	// exhaustion, rate-limit, 5xx) even after the write has already
+	// been applied server-side. Verify via a read: if the monitor is
+	// gone, the delete effectively succeeded — surface success so
+	// Terraform can drop it from state on the first run.
+	if _, getErr := client.GetMonitor(id); getErr != nil && strings.Contains(getErr.Error(), "not found") {
+		return nil
 	}
 	return
 }

--- a/internal/provider/api/status_page.go
+++ b/internal/provider/api/status_page.go
@@ -203,8 +203,13 @@ func (client UptimeRobotApiClient) DeleteStatusPage(id int) (err error) {
 		"deletePSP",
 		data.Encode(),
 	)
-	if err != nil {
+	if err == nil {
 		return
+	}
+
+	// Idempotent delete — see DeleteMonitor for rationale.
+	if _, getErr := client.GetStatusPage(id); getErr != nil && strings.Contains(getErr.Error(), "not found") {
+		return nil
 	}
 	return
 }


### PR DESCRIPTION
In the case where a large amount of deletions happen, the UptimeRobot API can drop responses, which is problematic because even though the resource itself is deleted then Terraform still doesn't know about it.

